### PR TITLE
Fixes problem when calling read after an error

### DIFF
--- a/lib/ior-peek.c
+++ b/lib/ior-peek.c
@@ -151,8 +151,13 @@ static off_t peek_read(io_t *io, void *buffer, off_t len)
 {
 	off_t ret = 0;
 
+        /* Have we previously encountered an error? */
+        if (DATA(io)->length < 0) {
+                return DATA(io)->length;
+        }
+
 	/* Is some of this data in the buffer? */
-	if (DATA(io)->buffer) {
+	if (DATA(io)->buffer && DATA(io)->length) {
 		ret = MIN(len,DATA(io)->length - DATA(io)->offset);
 
 		/* Copy anything we've got into their buffer, and shift our


### PR DESCRIPTION
I'm not precisely sure what happens, but I have some user code that I think is calling read after there is an error reading (perhaps the previous read was partially satisfied by the peek buffer). In this case, I believe `DATA(io)->length` is 0 (or -1) which causes some scary maths to happen, and then a memcpy of a negative number of bytes.
