### PR TITLE
Replace `off_t` with `int64_t`

### DIFF
--- a/lib/ior-bzip.c
+++ b/lib/ior-bzip.c
@@ -89,7 +89,7 @@ io_t *bz_open(io_t *parent)
 }
 
 
-static off_t bz_read(io_t *io, void *buffer, off_t len)
+static int64_t bz_read(io_t *io, void *buffer, int64_t len)
 {
 	if (DATA(io)->err == ERR_EOF)
 		return 0; /* EOF */

--- a/lib/ior-lzma.c
+++ b/lib/ior-lzma.c
@@ -85,7 +85,7 @@ io_t *lzma_open(io_t *parent)
 }
 
 
-static off_t lzma_read(io_t *io, void *buffer, off_t len)
+static int64_t lzma_read(io_t *io, void *buffer, int64_t len)
 {
 	if (DATA(io)->err == ERR_EOF)
 		return 0; /* EOF */

--- a/lib/ior-stdio.c
+++ b/lib/ior-stdio.c
@@ -75,17 +75,17 @@ io_t *stdio_open(const char *filename)
 	return io;
 }
 
-static off_t stdio_read(io_t *io, void *buffer, off_t len)
+static int64_t stdio_read(io_t *io, void *buffer, int64_t len)
 {
 	return read(DATA(io)->fd,buffer,len);
 }
 
-static off_t stdio_tell(io_t *io)
+static int64_t stdio_tell(io_t *io)
 {
 	return lseek(DATA(io)->fd, 0, SEEK_CUR);
 }
 
-static off_t stdio_seek(io_t *io, off_t offset, int whence)
+static int64_t stdio_seek(io_t *io, int64_t offset, int whence)
 {
 	return lseek(DATA(io)->fd, offset, whence);
 }

--- a/lib/ior-thread.c
+++ b/lib/ior-thread.c
@@ -73,7 +73,7 @@ struct state_t {
 	/* The index of the buffer to read into next */
 	int in_buffer;
 	/* The read offset into the current buffer */
-	off_t offset;
+	int64_t offset;
 	/* The reading thread */
 	pthread_t producer;
 	/* Indicates that there is a free buffer to read into */
@@ -196,7 +196,7 @@ io_t *thread_open(io_t *parent)
 	return state;
 }
 
-static off_t thread_read(io_t *state, void *buffer, off_t len)
+static int64_t thread_read(io_t *state, void *buffer, int64_t len)
 {
 	int slice;
 	int copied=0;

--- a/lib/ior-zlib.c
+++ b/lib/ior-zlib.c
@@ -89,7 +89,7 @@ io_t *zlib_open(io_t *parent)
 }
 
 
-static off_t zlib_read(io_t *io, void *buffer, off_t len)
+static int64_t zlib_read(io_t *io, void *buffer, int64_t len)
 {
 	if (DATA(io)->err == ERR_EOF)
 		return 0; /* EOF */

--- a/lib/iow-bzip.c
+++ b/lib/iow-bzip.c
@@ -88,7 +88,7 @@ iow_t *bz_wopen(iow_t *child, int compress_level)
 }
 
 
-static off_t bz_wwrite(iow_t *iow, const char *buffer, off_t len)
+static int64_t bz_wwrite(iow_t *iow, const char *buffer, int64_t len)
 {
 	if (DATA(iow)->err == ERR_EOF) {
 		return 0; /* EOF */

--- a/lib/iow-lzma.c
+++ b/lib/iow-lzma.c
@@ -89,7 +89,7 @@ iow_t *lzma_wopen(iow_t *child, int compress_level)
 }
 
 
-static off_t lzma_wwrite(iow_t *iow, const char *buffer, off_t len)
+static int64_t lzma_wwrite(iow_t *iow, const char *buffer, int64_t len)
 {
 	if (DATA(iow)->err == ERR_EOF) {
 		return 0; /* EOF */

--- a/lib/iow-lzo.c
+++ b/lib/iow-lzo.c
@@ -163,7 +163,7 @@ static void write8(struct buffer_t *buffer, uint8_t value)
 	write_buf(buffer, &value, sizeof(value));
 }
 
-static int lzo_wwrite_block(const char *buffer, off_t len, struct buffer_t *outbuf)
+static int lzo_wwrite_block(const char *buffer, int64_t len, struct buffer_t *outbuf)
 {
 	char b2[MAX_BUFFER_SIZE];
 	int err;
@@ -388,12 +388,12 @@ static struct lzothread_t *get_next_thread(iow_t *iow)
 	return &DATA(iow)->thread[DATA(iow)->next_thread];
 }
 
-static off_t lzo_wwrite(iow_t *iow, const char *buffer, off_t len)
+static int64_t lzo_wwrite(iow_t *iow, const char *buffer, int64_t len)
 {
-	off_t ret = 0;
+	int64_t ret = 0;
 	while (len>0) {
-		off_t size = len;
-		off_t err;
+		int64_t size = len;
+		int64_t err;
 		struct buffer_t outbuf;
 
 		if (!DATA(iow)->threads) {
@@ -419,7 +419,7 @@ static off_t lzo_wwrite(iow_t *iow, const char *buffer, off_t len)
 			}
 		}
 		else {
-			off_t space;
+			int64_t space;
 
 			pthread_mutex_lock(&get_next_thread(iow)->mutex);
 			/* If this thread is still compressing, wait for it to finish */

--- a/lib/iow-stdio.c
+++ b/lib/iow-stdio.c
@@ -141,7 +141,7 @@ iow_t *stdio_wopen(const char *filename,int flags)
  *
  * Since most writes are likely to be larger than MIN_WRITE_SIZE optimise for that case.
  */
-static off_t stdio_wwrite(iow_t *iow, const char *buffer, off_t len)
+static int64_t stdio_wwrite(iow_t *iow, const char *buffer, int64_t len)
 {
 	int towrite = len;
 	/* Round down size to the nearest multiple of MIN_WRITE_SIZE */

--- a/lib/iow-thread.c
+++ b/lib/iow-thread.c
@@ -71,7 +71,7 @@ struct state_t {
 	/* The collection of buffers (or slices) */
 	struct buffer_t buffer[BUFFERS];
 	/* The write offset into the current buffer */
-	off_t offset;
+	int64_t offset;
 	/* The writing thread */
 	pthread_t consumer;
 	/* The child writer */
@@ -183,7 +183,7 @@ iow_t *thread_wopen(iow_t *child)
 	return state;
 }
 
-static off_t thread_wwrite(iow_t *state, const char *buffer, off_t len)
+static int64_t thread_wwrite(iow_t *state, const char *buffer, int64_t len)
 {
 	int slice;
 	int copied=0;
@@ -201,7 +201,7 @@ static off_t thread_wwrite(iow_t *state, const char *buffer, off_t len)
 
 		/* Copy out of our main buffer into the next available slice */
 		slice=min( 
-			(off_t)sizeof(OUTBUFFER(state).buffer)-DATA(state)->offset,
+			(int64_t)sizeof(OUTBUFFER(state).buffer)-DATA(state)->offset,
 			len);
 				
 		pthread_mutex_unlock(&DATA(state)->mutex);
@@ -223,7 +223,7 @@ static off_t thread_wwrite(iow_t *state, const char *buffer, off_t len)
 		/* If we've filled a buffer, move on to the next one and 
 		 * signal to the write thread that there is something for it
 		 * to do */
-		if (DATA(state)->offset >= (off_t)sizeof(OUTBUFFER(state).buffer)) {
+		if (DATA(state)->offset >= (int64_t)sizeof(OUTBUFFER(state).buffer)) {
 			OUTBUFFER(state).state = FULL;
 			pthread_cond_signal(&DATA(state)->data_ready);
 			DATA(state)->offset = 0;

--- a/lib/iow-zlib.c
+++ b/lib/iow-zlib.c
@@ -93,7 +93,7 @@ iow_t *zlib_wopen(iow_t *child, int compress_level)
 }
 
 
-static off_t zlib_wwrite(iow_t *iow, const char *buffer, off_t len)
+static int64_t zlib_wwrite(iow_t *iow, const char *buffer, int64_t len)
 {
 	if (DATA(iow)->err == ERR_EOF) {
 		return 0; /* EOF */

--- a/lib/wandio.c
+++ b/lib/wandio.c
@@ -253,7 +253,7 @@ DLLEXPORT io_t *wandio_create_uncompressed(const char *filename) {
 }
 
 
-DLLEXPORT off_t wandio_tell(io_t *io)
+DLLEXPORT int64_t wandio_tell(io_t *io)
 {
 	if (!io->source->tell) {
 		errno = -ENOSYS;
@@ -262,7 +262,7 @@ DLLEXPORT off_t wandio_tell(io_t *io)
 	return io->source->tell(io);
 }
 
-DLLEXPORT off_t wandio_seek(io_t *io, off_t offset, int whence)
+DLLEXPORT int64_t wandio_seek(io_t *io, int64_t offset, int whence)
 {
 	if (!io->source->seek) {
 		errno = -ENOSYS;
@@ -271,9 +271,9 @@ DLLEXPORT off_t wandio_seek(io_t *io, off_t offset, int whence)
 	return io->source->seek(io,offset,whence);
 }
 
-DLLEXPORT off_t wandio_read(io_t *io, void *buffer, off_t len)
+DLLEXPORT int64_t wandio_read(io_t *io, void *buffer, int64_t len)
 { 
-	off_t ret;
+	int64_t ret;
 	ret=io->source->read(io,buffer,len); 
 #if READ_TRACE
 	fprintf(stderr,"%p: read(%s): %d bytes = %d\n",io,io->source->name, (int)len,(int)ret);
@@ -281,9 +281,9 @@ DLLEXPORT off_t wandio_read(io_t *io, void *buffer, off_t len)
 	return ret;
 }
 
-DLLEXPORT off_t wandio_peek(io_t *io, void *buffer, off_t len)
+DLLEXPORT int64_t wandio_peek(io_t *io, void *buffer, int64_t len)
 {
-	off_t ret;
+	int64_t ret;
 	assert(io->source->peek); /* If this fails, it means you're calling
 				   * peek on something that doesn't support
 				   * peeking.   Push a peek_open() on the io
@@ -351,7 +351,7 @@ DLLEXPORT iow_t *wandio_wcreate(const char *filename, int compress_type, int com
 		return iow;
 }
 
-DLLEXPORT off_t wandio_wwrite(iow_t *iow, const void *buffer, off_t len)
+DLLEXPORT int64_t wandio_wwrite(iow_t *iow, const void *buffer, int64_t len)
 {
 #if WRITE_TRACE
 	fprintf(stderr,"wwrite(%s): %d bytes\n",iow->source->name, (int)len);

--- a/lib/wandio.h
+++ b/lib/wandio.h
@@ -88,7 +88,7 @@ typedef struct {
 	 * @return The amount of bytes read, 0 if end of file is reached, -1
 	 * if an error occurs
 	 */
-	off_t (*read)(io_t *io, void *buffer, off_t len);
+	int64_t (*read)(io_t *io, void *buffer, int64_t len);
 
 	/** Reads from the IO source into the provided buffer but does not
 	 *  advance the read pointer.
@@ -99,14 +99,14 @@ typedef struct {
 	 * @return The amount of bytes read, 0 if end of file is reached, -1
 	 * if an error occurs
 	 */
-	off_t (*peek)(io_t *io, void *buffer, off_t len);
+	int64_t (*peek)(io_t *io, void *buffer, int64_t len);
 
 	/** Returns the current offset of the read pointer for an IO source.
 	 *
 	 * @param io		The IO reader to get the read offset for
 	 * @return The offset of the read pointer, or -1 if an error occurs
 	 */
-	off_t (*tell)(io_t *io);
+	int64_t (*tell)(io_t *io);
 	
 	/** Moves the read pointer for an IO source.
 	 * 
@@ -118,7 +118,7 @@ typedef struct {
 	 * 			for more details as to what these mean.
 	 * @return The value of the new read pointer, or -1 if an error occurs
 	 */
-	off_t (*seek)(io_t *io, off_t offset, int whence);
+	int64_t (*seek)(io_t *io, int64_t offset, int whence);
 	
 	/** Closes an IO reader. This function should free the IO reader.
 	 *
@@ -139,7 +139,7 @@ typedef struct {
 	 * @param len		The amount of writable data in the buffer
 	 * @return The amount of data written, or -1 if an error occurs
 	 */
-	off_t (*write)(iow_t *iow, const char *buffer, off_t len);
+	int64_t (*write)(iow_t *iow, const char *buffer, int64_t len);
 
 	/** Closes an IO writer. This function should free the IO writer. 
 	 *
@@ -257,7 +257,7 @@ io_t *wandio_create_uncompressed(const char *filename);
  * @param io		The IO reader to get the read offset for
  * @return The offset of the read pointer, or -1 if an error occurs
  */
-off_t wandio_tell(io_t *io);
+int64_t wandio_tell(io_t *io);
 
 /** Changes the read pointer offset to the specified value for a libwandio IO
  * reader.
@@ -271,7 +271,7 @@ off_t wandio_tell(io_t *io);
  * The arguments for this function are the same as those for lseek(2). See the
  * lseek(2) manpage for more details.
  */
-off_t wandio_seek(io_t *io, off_t offset, int whence);
+int64_t wandio_seek(io_t *io, int64_t offset, int whence);
 
 /** Reads from a libwandio IO reader into the provided buffer.
  *
@@ -280,7 +280,7 @@ off_t wandio_seek(io_t *io, off_t offset, int whence);
  * @param len		The size of the buffer
  * @return The amount of bytes read, 0 if EOF is reached, -1 if an error occurs
  */
-off_t wandio_read(io_t *io, void *buffer, off_t len);
+int64_t wandio_read(io_t *io, void *buffer, int64_t len);
 
 /** Reads from a libwandio IO reader into the provided buffer, but does not
  * update the read pointer.
@@ -290,7 +290,7 @@ off_t wandio_read(io_t *io, void *buffer, off_t len);
  * @param len		The size of the buffer
  * @return The amount of bytes read, 0 if EOF is reached, -1 if an error occurs
  */
-off_t wandio_peek(io_t *io, void *buffer, off_t len);
+int64_t wandio_peek(io_t *io, void *buffer, int64_t len);
 
 /** Destroys a libwandio IO reader, closing the file and freeing the reader
  * structure.
@@ -317,7 +317,7 @@ iow_t *wandio_wcreate(const char *filename, int compression_type, int compressio
  * @param len		The amount of writable data in the buffer
  * @return The amount of data written, or -1 if an error occurs
  */
-off_t wandio_wwrite(iow_t *iow, const void *buffer, off_t len);
+int64_t wandio_wwrite(iow_t *iow, const void *buffer, int64_t len);
 
 /** Destroys a libwandio IO writer, closing the file and freeing the writer
  * structure.

--- a/tools/wandiocat/wcat.c
+++ b/tools/wandiocat/wcat.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
                         continue;
                 }
 
-                off_t len;
+                int64_t len;
                 do {
                         len = wandio_read(ior, buffer, sizeof(buffer));
                         if (len > 0)


### PR DESCRIPTION
This will hopefully fix a nightmare problem when using libwandio on a 32bit system.

The problem is that internally, wandio uses the `AC_SYS_LARGEFILE` macro in
configure. On a 64 bit system this macro has no effect, and the `off_t` type is
64 bits wide. On a 32 bit system however, this macro causes `_FILE_OFFSET_BITS`
to be set to 64 (in `config.h`).

This is where things get scary. _If_ `config.h` is included _before_ any
header that uses/defines `off_t`, then `off_t` is a 64 bit field, otherwise it
is a 32 bit field. Since all `.c` files inside libwandio include `config.h`
(with the exception of `wcat.c`), `off_t` is always 64 bit. However, when an
external application uses libwandio, they will include `wandio.h`. Assuming they
are not using the AC_SYS_LARGEFILE configure macro, then when `wandio.h` is
included, `off_t` is a 32 bit field, and thus the various wandio function
prototypes that use `off_t` are declared as if they take a 32 bit value, when
actually the implementation takes a 64 bit value, wreaking havoc (since the
caller will push a 32-bit value onto the stack and the callee will pop a 64-bit
value off).

For a long time now I've been getting around this problem by ensuring that any
code that uses wandio uses the `AC_SYS_LARGEFILE` macro to convince `off_t` to
be 64 bits. I then have to be sure that `config.h` is always included before
`wandio.h`. This however, is not a complete solution, as other headers
(e.g. `stdio.h`) may result in `off_t` being defined, and if these headers are
included before `config.h` then the same problem occurs. Consider the following:

```
#include "myapp.h"
#include "config.h"
#include "wandio.h"
```

If `myapp.h` includes some header (e.g. `stdio.h`) that (indirectly) defines
off_t, then by the time `wandio.h` is included, `off_t` could be a 32 bit type.

Its a nasty problem since it can be quite hard to debug (in my experience it
manifests as a segfault when doing a `memcpy` inside `iow-thread.c`).

It seems that the correct solution is to never use `off_t` in any public API,
and instead use an explicitly-defined type. Since `off_t` is a signed integer
type, it seems to make sense to use `int64_t`.

I _think_ this change should be transparent to users in most cases. If they
are already using 64-bit `off_t` values (i.e., on a 64-bit arch, or using
_FILE_OFFSET_BITS), then the API does not change. However, if they are using 32
bit `off_t` values, then they will need to-recompile their code as the wandio
API will have changed (there shouldn't need to be any changes made to code
however).
