### PR TITLE
Fix wandio_wcreate function documentation minor error.

### DIFF
--- a/lib/wandio.h
+++ b/lib/wandio.h
@@ -305,7 +305,7 @@ void wandio_destroy(io_t *io);
  * @param compression_type	Compression type
  * @param compression_level	The compression level to use when writing
  * @param flags			Flags to apply when opening the file, e.g.
- * 				O_CREATE
+ * 				O_CREAT. See fcntl.h for more flags.
  * @return A pointer to the new libwandio IO writer, or NULL if an error occurs
  */
 iow_t *wandio_wcreate(const char *filename, int compression_type, int compression_level, int flags);


### PR DESCRIPTION
`O_CREATE` changed to `O_CREAT`. Also provided pointer to look for more flags.