### PR TITLE
[feature] Resume on download timeout

### DIFF
--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -281,8 +281,7 @@ static int64_t http_read(io_t *io, void *buffer, int64_t len)
 			ret = fill_buffer(io);
             if(ret == -1){
               continue;
-            }
-			if (ret < -1){
+            } else if (ret <= 0){
               break;
             } 
 		}

--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -283,15 +283,17 @@ static int64_t http_read(io_t *io, void *buffer, int64_t len)
 			rest -= DATA(io)->l_buf - DATA(io)->p_buf;
 			DATA(io)->p_buf = DATA(io)->l_buf;
 			ret = fill_buffer(io);
-            if(ret == FILL_FINISHED){
-              break;
-            } else if (ret == FILL_RETRY){
-              continue;
-            } else if (ret == FILL_RETRY_ERROR){
-              return -1;
-            } else {
-              return -2;
-            } 
+            if(ret <= 0){
+                if(ret == FILL_FINISHED){
+                    break;
+                } else if (ret == FILL_RETRY){
+                    continue;
+                } else if (ret == FILL_RETRY_ERROR){
+                    return -1;
+                } else {
+                    return -2;
+                } 
+            }
 		}
 	}
 	return len - rest;

--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -184,7 +184,7 @@ static int fill_buffer(io_t *io)
         if(DATA(io)->done_reading != 1 && DATA(io)->l_buf == 0){
           // reading unfinished, need to restart http instance
           int64_t ptr = DATA(io)->off0 + DATA(io)->p_buf + DATA(io)->l_buf;
-          if(!(init_io(io) && prepare(io))){
+          if(!init_io(io) || CURLE_OK != prepare(io)){
             // re-initiate IO failed
             printf("re-initiate IO failed\n");
           }

--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -95,7 +95,7 @@ extern io_source_t http_source;
 #define HTTP_DEF_BUFLEN   0x8000
 #define HTTP_MAX_SKIP     (HTTP_DEF_BUFLEN<<1)
 
-io_t *init_io(io_t *io, const char *filename);
+io_t *init_io(io_t *io);
 io_t *http_open(const char *filename);
 static int64_t http_read(io_t *io, void *buffer, int64_t len);
 static int64_t http_tell(io_t *io);
@@ -178,7 +178,7 @@ static int fill_buffer(io_t *io)
         if(DATA(io)->done_reading != 1 && DATA(io)->l_buf == 0){
           // read unfinished, need to restart http instance
           int64_t ptr = DATA(io)->off0 + DATA(io)->p_buf + DATA(io)->l_buf;
-          if(!init_io(io, NULL)){
+          if(!init_io(io)){
             // re-initiate IO failed
             return -1;
           }
@@ -197,7 +197,9 @@ io_t *http_open(const char *filename)
     return NULL;
   }
 
-  if(!init_io(io, filename)){
+  /* set url */
+  DATA(io) -> url = filename;
+  if(!init_io(io)){
     return NULL;
   }
 
@@ -209,7 +211,7 @@ io_t *http_open(const char *filename)
   return io;
 }
 
-io_t *init_io(io_t *io, const char *filename){
+io_t *init_io(io_t *io){
         if (!io) return NULL;
         if(DATA(io)->buf){
           // free buffer if already exists
@@ -217,11 +219,6 @@ io_t *init_io(io_t *io, const char *filename){
         }
 
         io->source = &http_source;
-
-        /* set url */
-        if(filename != NULL){
-          DATA(io) -> url = filename;
-        }
 
         /* set up global curl structures (see note above) */
         pthread_mutex_lock(&cg_lock);

--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -278,7 +278,7 @@ static int64_t http_read(io_t *io, void *buffer, int64_t len)
 			rest -= DATA(io)->l_buf - DATA(io)->p_buf;
 			DATA(io)->p_buf = DATA(io)->l_buf;
 			ret = fill_buffer(io);
-			if (ret == 0) break;
+			if (ret <= 0) break;
 		}
 	}
 	return len - rest;

--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -169,7 +169,7 @@ static int fill_buffer(io_t *io)
                     // update file length.
                     double cl;
                     curl_easy_getinfo(DATA(io) -> curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
-                    DATA(io) -> total_length = (unsigned long long int) cl;
+                    DATA(io) -> total_length = (int64_t) cl;
                 }
         } while (n_running &&
                  DATA(io)->l_buf < DATA(io)->m_buf - CURL_MAX_WRITE_SIZE);
@@ -206,7 +206,7 @@ io_t *http_open(const char *filename)
 
   /* set url */
   DATA(io) -> url = filename;
-  DATA(io) -> total_length = -2;
+  DATA(io) -> total_length = -1;
   if(!init_io(io)){
     return NULL;
   }


### PR DESCRIPTION
When opening an HTTP connection, it keeps track of the size of the file to download and reopen connection if the download is unfinished. This would allow wandio to continue reading through a remote file even after the remote timed out or the connection is temporarily lost.