### PR TITLE
Remove AC_C_INLINE from configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,6 @@ AC_FUNC_REALLOC
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
-AC_C_INLINE
 AC_C_BIGENDIAN
 AC_TYPE_SIZE_T
 AC_HEADER_TIME


### PR DESCRIPTION
It turns out that this macro triggers a compiler warning on LLVM which causes the macro to incorrectly decide that the compiler doesn't support `inline` so it then `#define`'s it to nothing, which ends up breaking some libc functions that are implemented as macros.

Probably the right way to fix it is to redefine the macro as described at http://lists.gnu.org/archive/html/autoconf-patches/2014-06/msg00000.html but since we don't actually use inline anywhere this seems pointless. At the point we decide to use inline (and when someone wants to build wandio with a compiler that doesn't support it) we can reconsider this.