### PR TITLE
Only attempt to change file ownership if current owner is root

### DIFF
--- a/lib/iow-stdio.c
+++ b/lib/iow-stdio.c
@@ -87,19 +87,20 @@ static int safe_open(const char *filename, int flags)
 	 * original user rather than root.
 	 *
 	 * TODO: make this some sort of config option */
+	if (getuid() == 0) {
+		sudoenv = getenv("SUDO_UID");
+		if (sudoenv != NULL) {
+			userid = strtol(sudoenv, NULL, 10);
+		}
+		sudoenv = getenv("SUDO_GID");
+		if (sudoenv != NULL) {
+			groupid = strtol(sudoenv, NULL, 10);
+		}
 
-	sudoenv = getenv("SUDO_UID");
-	if (sudoenv != NULL) {
-		userid = strtol(sudoenv, NULL, 10);
-	}
-	sudoenv = getenv("SUDO_GID");
-	if (sudoenv != NULL) {
-		groupid = strtol(sudoenv, NULL, 10);
-	}
-	
-	if (userid != 0 && fchown(fd, userid, groupid) == -1) {
-		perror("fchown");
-		return -1;
+		if (userid != 0 && fchown(fd, userid, groupid) == -1) {
+			perror("fchown");
+			return -1;
+		}
 	}
 
 	return fd;


### PR DESCRIPTION
Previously if the process was being run by sudo, this code block attempted to chown the created file to be owned by the user who had invoked sudo. This worked in the "normal" case where sudo was used to run a capture application as root, but if sudo is being used to run an application as another (non-root) user, then the chown would fail.