### PR TITLE
Replace use of `off_t` with `int64_t`

### DIFF
--- a/lib/wandio.c
+++ b/lib/wandio.c
@@ -487,7 +487,7 @@ DLLEXPORT void wandio_wdestroy(iow_t *iow) {
 
 /** Alistair's API extensions from "wandio_util" */
 
-DLLEXPORT int64_t wandio_generic_fgets(void *file, void *buffer, off_t len,
+DLLEXPORT int64_t wandio_generic_fgets(void *file, void *buffer, int64_t len,
                                 int chomp, read_cb_t *read_cb) {
         assert(file != NULL);
 
@@ -588,7 +588,7 @@ DLLEXPORT int wandio_detect_compression_type(const char *filename) {
         return WANDIO_COMPRESS_NONE;
 }
 
-DLLEXPORT inline off_t wandio_vprintf(iow_t *file, const char *format,
+DLLEXPORT inline int64_t wandio_vprintf(iow_t *file, const char *format,
                                       va_list args) {
         assert(file != NULL);
         char *buf;
@@ -605,7 +605,7 @@ DLLEXPORT inline off_t wandio_vprintf(iow_t *file, const char *format,
         return len;
 }
 
-DLLEXPORT inline off_t wandio_printf(iow_t *file, const char *format, ...) {
+DLLEXPORT inline int64_t wandio_printf(iow_t *file, const char *format, ...) {
         va_list ap;
 
         va_start(ap, format);

--- a/lib/wandio.h
+++ b/lib/wandio.h
@@ -376,7 +376,7 @@ typedef int64_t(read_cb_t)(void *file, void *buffer, int64_t len);
  * @param chomp         Should the newline be removed
  * @return the number of bytes actually read
  */
-int64_t wandio_generic_fgets(void *file, void *buffer, off_t len, int chomp,
+int64_t wandio_generic_fgets(void *file, void *buffer, int64_t len, int chomp,
                       read_cb_t *read_cb);
 
 /** Read a line from the given wandio file pointer
@@ -406,7 +406,7 @@ int wandio_detect_compression_type(const char *filename);
  * The arguments for this function are the same as those for vprintf(3). See the
  * vprintf(3) manpage for more details.
  */
-off_t wandio_vprintf(iow_t *file, const char *format, va_list args);
+int64_t wandio_vprintf(iow_t *file, const char *format, va_list args);
 
 /** Print a string to a wandio file using a printf-style API
  *
@@ -418,7 +418,7 @@ off_t wandio_vprintf(iow_t *file, const char *format, va_list args);
  * The arguments for this function are the same as those for printf(3). See the
  * printf(3) manpage for more details.
  */
-off_t wandio_printf(iow_t *file, const char *format, ...);
+int64_t wandio_printf(iow_t *file, const char *format, ...);
 
 /** @} */
 #ifdef __cplusplus


### PR DESCRIPTION
We addressed this originally in d385220367982fde1aa29ff0764dbfac58f5c8b7, but recently added helper functions (based on an older version of wandio) were still using `off_t`.