### PR TITLE
iow-thread: do not use EMPTY buffer when closing

### DIFF
--- a/lib/iow-thread.c
+++ b/lib/iow-thread.c
@@ -118,9 +118,11 @@ static void *thread_consumer(void *userdata) {
                 }
                 /* Empty the buffer using the child writer */
                 pthread_mutex_unlock(&DATA(state)->mutex);
-                wandio_wwrite(DATA(state)->iow,
-                              DATA(state)->buffer[buffer].buffer,
-                              DATA(state)->buffer[buffer].len);
+                if (DATA(state)->buffer[buffer].len > 0) {
+                        wandio_wwrite(DATA(state)->iow,
+                                      DATA(state)->buffer[buffer].buffer,
+                                      DATA(state)->buffer[buffer].len);
+                }
                 if (DATA(state)->buffer[buffer].flush) {
                         wandio_wflush(DATA(state)->iow);
                 }


### PR DESCRIPTION
In thread_consumer, when we exit the inner loop because the program is over,
the current buffer must be EMPTY; otherwise, we would have exited the inner
loop normally.  This EMPTY buffer is then passed to wandio_wwrite, where an
uninitialized memory read occurs.

Instead, jump right to the cleanup after the inner loop.

Found with Valgrind.