### PR TITLE
Add DLLEXPORT to the *_open and *_wopen functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Version 4.2.0
  * Replaced 'off_t' parameters and return values with 'int64_t' in
    recently added API functions.
  * Fixed potential uninitialised memory error when closing a wandio writer.
+ * Export symbols for all format-specific open functions.
 
 Version 4.1.2
 =============

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ libwandio1 (4.2.0-1) unstable; urgency=medium
   * Replaced 'off_t' parameters and return values with 'int64_t' in
     recently added API functions.
   * Fixed potential uninitialised memory error when closing a wandio writer.
+  * Export symbols for all format-specific 'open' functions.
 
  -- Shane Alcock <salcock@waikato.ac.nz>  Fri, 10 May 2019 13:31:49 +1200
 

--- a/lib/ior-bzip.c
+++ b/lib/ior-bzip.c
@@ -51,7 +51,7 @@ extern io_source_t bz_source;
 #define DATA(io) ((struct bz_t *)((io)->data))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-io_t *bz_open(io_t *parent) {
+DLLEXPORT io_t *bz_open(io_t *parent) {
         io_t *io;
         if (!parent)
                 return NULL;

--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -240,7 +240,8 @@ static int fill_buffer(io_t *io) {
         return DATA(io)->l_buf;
 }
 
-io_t *http_open_hdrs(const char *filename, char **hdrs, int hdrs_cnt) {
+DLLEXPORT io_t *http_open_hdrs(const char *filename, char **hdrs, int hdrs_cnt)
+{
         io_t *io = malloc(sizeof(io_t));
         if (!io)
                 return NULL;
@@ -270,7 +271,7 @@ io_t *http_open_hdrs(const char *filename, char **hdrs, int hdrs_cnt) {
         return io;
 }
 
-io_t *http_open(const char *filename) {
+DLLEXPORT io_t *http_open(const char *filename) {
         return http_open_hdrs(filename, NULL, 0);
 }
 

--- a/lib/ior-lzma.c
+++ b/lib/ior-lzma.c
@@ -51,7 +51,7 @@ extern io_source_t lzma_source;
 #define DATA(io) ((struct lzma_t *)((io)->data))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-io_t *lzma_open(io_t *parent) {
+DLLEXPORT io_t *lzma_open(io_t *parent) {
         io_t *io;
         if (!parent)
                 return NULL;

--- a/lib/ior-peek.c
+++ b/lib/ior-peek.c
@@ -65,7 +65,7 @@ extern io_source_t peek_source;
 #define DATA(io) ((struct peek_t *)((io)->data))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-io_t *peek_open(io_t *child) {
+DLLEXPORT io_t *peek_open(io_t *child) {
         io_t *io;
         if (!child)
                 return NULL;

--- a/lib/ior-qat.c
+++ b/lib/ior-qat.c
@@ -80,7 +80,7 @@ struct qat_t {
         enum err_t err;
 };
 
-io_t *qat_open(io_t *parent) {
+DLLEXPORT io_t *qat_open(io_t *parent) {
 
         int x;
         io_t *io;

--- a/lib/ior-stdio.c
+++ b/lib/ior-stdio.c
@@ -46,7 +46,7 @@ extern io_source_t stdio_source;
 
 #define DATA(io) ((struct stdio_t *)((io)->data))
 
-io_t *stdio_open(const char *filename) {
+DLLEXPORT io_t *stdio_open(const char *filename) {
         io_t *io = malloc(sizeof(io_t));
         io->data = malloc(sizeof(struct stdio_t));
 

--- a/lib/ior-swift.c
+++ b/lib/ior-swift.c
@@ -65,7 +65,7 @@ extern io_source_t swift_source;
 #define SWIFT_PFX_LEN 8
 #define SWIFT_AUTH_TOKEN_HDR "X-Auth-Token: "
 
-io_t *swift_open(const char *filename);
+DLLEXPORT io_t *swift_open(const char *filename);
 static int64_t swift_read(io_t *io, void *buffer, int64_t len);
 static int64_t swift_tell(io_t *io);
 static int64_t swift_seek(io_t *io, int64_t offset, int whence);

--- a/lib/ior-thread.c
+++ b/lib/ior-thread.c
@@ -152,7 +152,7 @@ static void *thread_producer(void *userdata) {
         return NULL;
 }
 
-io_t *thread_open(io_t *parent) {
+DLLEXPORT io_t *thread_open(io_t *parent) {
         io_t *state;
         sigset_t set;
         int s;

--- a/lib/ior-zlib.c
+++ b/lib/ior-zlib.c
@@ -53,7 +53,7 @@ extern io_source_t zlib_source;
 #define DATA(io) ((struct zlib_t *)((io)->data))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-io_t *zlib_open(io_t *parent) {
+DLLEXPORT io_t *zlib_open(io_t *parent) {
         io_t *io;
         if (!parent)
                 return NULL;

--- a/lib/ior-zstd-lz4.c
+++ b/lib/ior-zstd-lz4.c
@@ -64,7 +64,7 @@ struct zstd_lz4_t {
 #define DATA(io) ((struct zstd_lz4_t *)((io)->data))
 extern io_source_t zstd_lz4_source;
 
-io_t *zstd_lz4_open(io_t *parent) {
+DLLEXPORT io_t *zstd_lz4_open(io_t *parent) {
         io_t *io;
         if (!parent) {
                 return NULL;

--- a/lib/iow-bzip.c
+++ b/lib/iow-bzip.c
@@ -50,7 +50,7 @@ extern iow_source_t bz_wsource;
 #define DATA(iow) ((struct bzw_t *)((iow)->data))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-iow_t *bz_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *bz_wopen(iow_t *child, int compress_level) {
         iow_t *iow;
         if (!child)
                 return NULL;

--- a/lib/iow-lz4.c
+++ b/lib/iow-lz4.c
@@ -54,7 +54,7 @@ struct lz4w_t {
 #define DATA(iow) ((struct lz4w_t *)((iow)->data))
 extern iow_source_t lz4_wsource;
 
-iow_t *lz4_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *lz4_wopen(iow_t *child, int compress_level) {
         iow_t *iow;
         if (!child) {
                 return NULL;

--- a/lib/iow-lzma.c
+++ b/lib/iow-lzma.c
@@ -51,7 +51,7 @@ extern iow_source_t lzma_wsource;
 #define DATA(iow) ((struct lzmaw_t *)((iow)->data))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-iow_t *lzma_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *lzma_wopen(iow_t *child, int compress_level) {
         iow_t *iow;
         if (!child)
                 return NULL;

--- a/lib/iow-lzo.c
+++ b/lib/iow-lzo.c
@@ -265,7 +265,7 @@ static void *lzo_compress_thread(void *data) {
         return NULL;
 }
 
-iow_t *lzo_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *lzo_wopen(iow_t *child, int compress_level) {
         const int opt_filter = 0;
         int flags;
         iow_t *iow;

--- a/lib/iow-qat.c
+++ b/lib/iow-qat.c
@@ -79,7 +79,7 @@ static void qat_perror(int errcode) {
         }
 }
 
-iow_t *qat_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *qat_wopen(iow_t *child, int compress_level) {
 
         iow_t *iow;
         QzSessionParams_T params;

--- a/lib/iow-stdio.c
+++ b/lib/iow-stdio.c
@@ -96,7 +96,7 @@ static int safe_open(const char *filename, int flags) {
         return fd;
 }
 
-iow_t *stdio_wopen(const char *filename, int flags) {
+DLLEXPORT iow_t *stdio_wopen(const char *filename, int flags) {
         iow_t *iow = malloc(sizeof(iow_t));
         iow->source = &stdio_wsource;
         iow->data = malloc(sizeof(struct stdiow_t));

--- a/lib/iow-thread.c
+++ b/lib/iow-thread.c
@@ -150,7 +150,7 @@ static void *thread_consumer(void *userdata) {
         return NULL;
 }
 
-iow_t *thread_wopen(iow_t *child) {
+DLLEXPORT iow_t *thread_wopen(iow_t *child) {
         iow_t *state;
 
         if (!child) {

--- a/lib/iow-zlib.c
+++ b/lib/iow-zlib.c
@@ -51,7 +51,7 @@ extern iow_source_t zlib_wsource;
 #define DATA(iow) ((struct zlibw_t *)((iow)->data))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-iow_t *zlib_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *zlib_wopen(iow_t *child, int compress_level) {
         iow_t *iow;
         if (!child)
                 return NULL;

--- a/lib/iow-zstd.c
+++ b/lib/iow-zstd.c
@@ -46,7 +46,7 @@ struct zstdw_t {
 #define DATA(iow) ((struct zstdw_t *)((iow)->data))
 extern iow_source_t zstd_wsource;
 
-iow_t *zstd_wopen(iow_t *child, int compress_level) {
+DLLEXPORT iow_t *zstd_wopen(iow_t *child, int compress_level) {
         iow_t *iow;
         if (!child)
                 return NULL;


### PR DESCRIPTION
These functions were already in the wandio.h header and some
users would like to access them (the HTTP ones, in particular),
directly without the extra wandio overhead. Without DLLEXPORT,
the symbols are only available internally so this commit fixes
that.

Long term, we need to re-evaluate the structure of wandio and
how things should be arranged / made available to best suit the
modern use cases that people have for it.