### PR TITLE
fix formatter warning

### DIFF
--- a/lib/iow-lz4.c
+++ b/lib/iow-lz4.c
@@ -145,7 +145,7 @@ static int64_t lz4_wwrite(iow_t *iow, const char *buffer, int64_t len) {
 
                 if (upper_bound > (int64_t)sizeof(DATA(iow)->outbuf) ||
                                 upper_bound < 0) {
-                        fprintf(stderr, "invalid upper bound calculated by lz4 library: %d\n", upper_bound);
+                        fprintf(stderr, "invalid upper bound calculated by lz4 library: %zu\n", upper_bound);
                         errno = EINVAL;
                         return -1;
                 }


### PR DESCRIPTION
`size_t` should be formatted with `%zu` rather than `%d`

```
iow-lz4.c:148:96: warning: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                        fprintf(stderr, "invalid upper bound calculated by lz4 library: %d\n", upper_bound);
                                                                                        ~~     ^~~~~~~~~~~
                                                                                        %zu
1 warning generated.
```