### PR TITLE
Fix HTTP reader when using libcurl < 7.20.0

### DIFF
--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -186,9 +186,11 @@ static int fill_buffer(io_t *io) {
                         nanosleep(&req, &rem);
                 }
                 curl_easy_pause(DATA(io)->curl, CURLPAUSE_CONT);
-                if (curl_multi_perform(DATA(io)->multi, &n_running) !=
-                    CURLM_OK) {
-                  return -1;
+                do {
+                        rc = curl_multi_perform(DATA(io)->multi, &n_running);
+                } while (rc == CURLM_CALL_MULTI_PERFORM);
+                if (rc != CURLM_OK) {
+                        return -1;
                 }
                 if (DATA(io)->total_length < 0) {
                         // update file length.


### PR DESCRIPTION
According to libcurl documentation
(https://curl.haxx.se/libcurl/c/curl_multi_perform.html), prior to libcurl
7.20.0, `curl_multi_perform` may return `CURLM_CALL_MULTI_PERFORM` if you should
immediately call `curl_multi_perform` again. After 7.20.0 this return code is
never used
(https://curl.haxx.se/libcurl/c/libcurl-errors.html#CURLMCALLMULTIPERFORM).