### PR TITLE
set CURLOPT_FAILONERROR to fail on HTTP error

### DIFF
--- a/lib/ior-http.c
+++ b/lib/ior-http.c
@@ -299,6 +299,7 @@ io_t *init_io(io_t *io) {
         curl_easy_setopt(DATA(io)->curl, CURLOPT_SSL_VERIFYPEER, 1L);
         curl_easy_setopt(DATA(io)->curl, CURLOPT_SSL_VERIFYHOST, 1L);
         curl_easy_setopt(DATA(io)->curl, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(DATA(io)->curl, CURLOPT_FAILONERROR, 1L);
         curl_easy_setopt(DATA(io)->curl, CURLOPT_USERAGENT, "wandio/"PACKAGE_VERSION);
 
         /* for remote files, the buffer set to 2*CURL_MAX_WRITE_SIZE */


### PR DESCRIPTION
setting `CURLOPT_FAILONERROR` for curl allows it to properly fail when
HTTP error (HTTP response >= 400) is returned.

if not set, the return code for `curl_multi_perform` will be `CURLM_OK`
even if HTTP error happens.

Tested with `wandiocat`:

Before patch:
```
$ wandiocat https://httpstat.us/500
500 Internal Server Error
$ echo $?
0
```

After patch:
```
$ wandiocat https://httpstat.us/500
HTTP ERROR: HTTP response code said error (22)
Failed to open https://httpstat.us/500
$ echo $?
1
```

reference: https://curl.haxx.se/libcurl/c/CURLOPT_FAILONERROR.html